### PR TITLE
Wrap list items in list-group

### DIFF
--- a/sjakkrating/client/templates/top_list.html
+++ b/sjakkrating/client/templates/top_list.html
@@ -53,10 +53,10 @@
 	<div class="col-md-3 col-sm-6">
 		<div class="panel panel-default">
 		  <div class="panel-heading"><b>Sjakklubber</b></div>
+		  <ul class="list-group">
 		  	{{#each listClubs}}
 			  		<li class="list-group-item"><a href="{{pathFor 'clubPage' _id=this.name}}">{{name}}</a></li>
 		  	{{/each}}
-		  <ul class="list-group">
 		  </ul>
 		</div>
 	</div>


### PR DESCRIPTION
The list-group was incorrectly placed after all the list items for one of the top lists, resulting in a small layout bug.

Disclaimer: I did not set up and test this locally, only tested the equivalent changes in the web inspector.

**Before:**
<img width="669" alt="screenshot 2015-12-10 15 23 19" src="https://cloud.githubusercontent.com/assets/1413267/11718336/bd3ba4fe-9f55-11e5-8ded-23c6f3750dce.png">

**After:**
<img width="680" alt="screenshot 2015-12-10 15 48 37" src="https://cloud.githubusercontent.com/assets/1413267/11718335/bd11aae6-9f55-11e5-96b8-27a8931f1c38.png">
